### PR TITLE
Add Token to access private submodules

### DIFF
--- a/.github/workflows/lock-deps.yml
+++ b/.github/workflows/lock-deps.yml
@@ -14,8 +14,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-        # with:
-        #   submodules: recursive
+        with:
+          submodules: recursive
+          token: ${{ secrets.TOKEN }} # 使用 GitHub Token
 
       - name: Update submodules
         run: |-


### PR DESCRIPTION
Add Token to access private submodules
1. Generate a personal access token
2. Add Secret to the repository
3. Once added, you can access the private submodule in GitHub Actions